### PR TITLE
tekin announce deployment

### DIFF
--- a/config/dev/.tekin-secrets.yaml
+++ b/config/dev/.tekin-secrets.yaml
@@ -6,3 +6,4 @@ slack:
     bot_auth: bot
     app_auth: app
     tekin_id: @tekin
+    deploy_channe: GTEKIN123

--- a/tekinbot/tekin.py
+++ b/tekinbot/tekin.py
@@ -7,6 +7,7 @@ from pyramid.response import Response
 
 import tekinbot.comms as comms
 import tekinbot.utils.db as du
+from tekinbot.utils.post import deploy_view
 
 
 def tekin_args():
@@ -82,6 +83,8 @@ def create_application(dry_run=False, nodb=False):
     with Configurator() as config:
         config.add_route('main', '/')
         config.add_view(dry_main if dry_run else main, route_name='main')
+        config.add_route('deploy', '/deploy')
+        config.add_view(deploy_view)
         return config.make_wsgi_app()
 
 

--- a/tekinbot/utils/post.py
+++ b/tekinbot/utils/post.py
@@ -2,7 +2,7 @@ import json
 import subprocess
 
 import requests
-from pyramid.respose import Response
+from pyramid.response import Response
 
 from tekinbot.utils.config import tekin_secrets
 

--- a/tekinbot/utils/post.py
+++ b/tekinbot/utils/post.py
@@ -1,6 +1,8 @@
 import json
+import subprocess
 
 import requests
+from pyramid.respose import Response
 
 from tekinbot.utils.config import tekin_secrets
 
@@ -37,3 +39,27 @@ def post_plain_text(request, resp, auth, channel=None):
         data=json.dumps(content),
     )
     return post_resp
+
+
+def deploy_view(request):
+    new_commit = subprocess.check_output(['git', 'rev-parse', 'master'])
+    new_commit = new_commit.decode('utf-8')
+    new_commit_msg = subprocess.check_output(['git', 'log', '--pretty=%B'])
+    new_commit_msg = new_commit_msg.decode('utf-8')
+
+    deploy_channel = tekin_secrets('slack.deploy_channel')
+    if not deploy_channel:
+        return Response('deploy channel not configured, deploy not announced')
+    deploy_message = (
+        f'New commit new Tekin! '
+        f'A new version (SHA: {new_commit}) of TekinBot was just deployed! \n'
+        f'The new version consists of the following changes: \n'
+        f'{new_commit_msg}'
+    )
+    post_plain_text(
+        request,
+        deploy_message,
+        app_auth(),
+        channel=deploy_channel,
+    )
+    return Response()


### PR DESCRIPTION
Tekin now announces the new version of itself in a designated channel of your choice, configure it in tekin-secrets, if it is not set, tekin will not announce the deployment.