### PR TITLE
tekinbot to use standard mtgfetcher format

### DIFF
--- a/tekinbot/comms/message/__init__.py
+++ b/tekinbot/comms/message/__init__.py
@@ -28,7 +28,6 @@ def process(request):
     # return responses, in tuples: (regex_obj, response)
     # responses are always in a list, if empty list, no response
     resps = []
-    print(comms_dict.keys())
     for r in comms_dict:
         try:
             if re.match(r, request['event']['text']):

--- a/tekinbot/comms/message/searching/scryfall.py
+++ b/tekinbot/comms/message/searching/scryfall.py
@@ -7,8 +7,9 @@ from tekinbot.utils.config import tekin_id
 
 
 comm_re = re.compile(
-    f'^{tekin_id} :?(mtg me|mtg)'
-    f'(?P<exact> exactly|)(: |:| )(?P<query>.*)$',
+    f'(^{tekin_id} :?(mtg me|mtg)'
+    f'(?P<exact> exactly|)(: |:| )(?P<query>.*)$|'
+    f'^.*\[\[(?P<exact_bk>!)?(?P<query_bk>.*)\]\].*$)',
     flags=re.IGNORECASE
 )
 
@@ -39,15 +40,15 @@ def search(query, exact):
             f'query:\n{resp["image_uris"]["large"]}. Try to be more '
             'precise if this is not it.'
         )
-    except Exception:
+    except Exception as e:
+        print(e)
         return 'Can\'t find the said card.'
 
 
 def process(request):
-    print('called')
     match = re.fullmatch(comm_re, request['event']['text'])
-    query = match.group('query')
-    exact = bool(match.group('exact'))
+    query = match.group('query') or match.group('query_bk')
+    exact = bool(match.group('exact') or match.group('exact_bk'))
 
     if not query:
         return 'What exactly are you looking for?'

--- a/tests/comms/message/searching/test_scryfall.py
+++ b/tests/comms/message/searching/test_scryfall.py
@@ -29,6 +29,8 @@ class TestYoutube(object):
         (f'{tekin_id} mtg: something', True),
         (f'{tekin_id} mtg:something', True),
         (f'{tekin_id} mtg exactly: something', True),
+        (f'[[something]]', True),
+        (f'something [[something]] else', True),
     ])
     def test_comm_re(self, text, match):
         assert bool(re.fullmatch(
@@ -39,6 +41,9 @@ class TestYoutube(object):
     @pytest.mark.parametrize('text, query, exact', [
         (f'{tekin_id} mtg me something', 'something', False),
         (f'{tekin_id} mtg me exactly something', 'something', True),
+        (f'[[!something]]', 'something', True),
+        (f'some [[!something]] thing else', 'something', True),
+        (f'some [[something]] thing else', 'something', False),
     ])
     def test_process(
         self, text, query, exact,


### PR DESCRIPTION
Tekinbot's scryfall function now support the standard [[card name]] format.
removed some print functions used for debugging.